### PR TITLE
updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > just the same.
 
 ## Installation:
- - Install via composer `composer install jason-napolitano/codeigniter4-cart-module`
+ - Install via composer `composer require jason-napolitano/codeigniter4-cart-module`
  - Add it to the `$psr4` array in `app/Config/Autoload.php`:
  ```php
 $psr4 = [


### PR DESCRIPTION
changed "composer install" to "composer require" because composer install doesn't install but composer require does